### PR TITLE
PostItem 컴포넌트 구현 (#5)

### DIFF
--- a/FRONT/src/App.css
+++ b/FRONT/src/App.css
@@ -2,6 +2,7 @@
   margin: 0;
   padding: 0;
   font-size: 14px;
+  color: var(--text-color)
 }
 
 h1 {
@@ -27,4 +28,5 @@ h4 {
 p {
   font-size: 14px;
   font-weight: 400;
+  line-height: 20px;
 }

--- a/FRONT/src/App.tsx
+++ b/FRONT/src/App.tsx
@@ -1,33 +1,13 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { Route, Routes } from 'react-router-dom'
 import './App.css'
+import Home from './pages/Home/Home'
 
 function App() {
-  const [count, setCount] = useState(0)
-
   return (
     <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
-        </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
+      <Routes>
+        <Route path='/' element={<Home />} />
+      </Routes>
     </>
   )
 }

--- a/FRONT/src/main.tsx
+++ b/FRONT/src/main.tsx
@@ -2,9 +2,12 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
+import { BrowserRouter } from 'react-router-dom'
 
 createRoot(document.getElementById('root')!).render(
-  <StrictMode>
-    <App />
-  </StrictMode>,
+  <BrowserRouter>
+    <StrictMode>
+      <App />
+    </StrictMode>
+  </BrowserRouter>
 )

--- a/FRONT/src/pages/Home/Home.tsx
+++ b/FRONT/src/pages/Home/Home.tsx
@@ -1,0 +1,24 @@
+import styled from "styled-components";
+import PostItem from "./components/PostItem/PostItem";
+
+const TempWrapper = styled.main`
+  max-width: 700px;
+  padding: 30px 20px;
+`
+
+function Home() {
+  return (
+    <TempWrapper>
+      <PostItem 
+        title="뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목"
+        createdAt="2024-11-12"
+        content="요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.
+        요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. "
+        userIntro="어쩌구 저쩌구 개발자입니다."
+        userName="도안탄히엔"
+        />
+    </TempWrapper>
+  )
+}
+
+export default Home;

--- a/FRONT/src/pages/Home/components/PostItem/PostItem.style.ts
+++ b/FRONT/src/pages/Home/components/PostItem/PostItem.style.ts
@@ -1,0 +1,68 @@
+import { styled } from 'styled-components';
+
+export const Wrapper = styled.article`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 30px 5px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+
+  & > a {
+    text-decoration: none;
+  }
+`;
+
+export const Title = styled.h3`
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`
+
+export const UserProfileWrapper = styled.div`
+  display: flex;
+  gap: 5px;
+  width: 100%;
+  align-items: center;
+`
+
+export const UserImage = styled.figure`
+  padding: 0;
+  margin: 0;
+  width: 35px;
+  height: 35px;
+  border-radius: 100%;
+  overflow: hidden;
+  display: flex:
+  justify-content: center;
+  aligh-items: center;
+  flex: none;
+`;
+
+export const UserInfoWrapper = styled.article`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+export const UserNameWrapper = styled.div`
+  display: flex;
+  gap: 2px;
+`;
+
+export const UserName = styled.span`
+  font-size: 12px;
+`;
+
+export const SubInfo = styled.span`
+  font-size: 12px;
+  color: #AAA;
+`;
+
+export const Content = styled.p`
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`;

--- a/FRONT/src/pages/Home/components/PostItem/PostItem.style.ts
+++ b/FRONT/src/pages/Home/components/PostItem/PostItem.style.ts
@@ -66,3 +66,8 @@ export const Content = styled.p`
   -webkit-box-orient: vertical;
   overflow: hidden;
 `;
+
+export const TagContainer = styled.span`
+  color: var(--point-color);
+  font-size: 12px;
+`

--- a/FRONT/src/pages/Home/components/PostItem/PostItem.tsx
+++ b/FRONT/src/pages/Home/components/PostItem/PostItem.tsx
@@ -2,6 +2,7 @@ import { Link } from 'react-router-dom';
 import { 
   Content, 
   SubInfo, 
+  TagContainer, 
   Title, 
   UserImage, 
   UserInfoWrapper, 
@@ -22,6 +23,9 @@ interface PostItemProps {
 function PostItem({ title, content, createdAt, userName, userIntro }: PostItemProps) {
   return (
     <Wrapper>
+      <TagContainer>
+        Software Engineering &gt; CI/CD
+      </TagContainer>
       <Link to="#">
         <Title>{ title }</Title>
       </Link>

--- a/FRONT/src/pages/Home/components/PostItem/PostItem.tsx
+++ b/FRONT/src/pages/Home/components/PostItem/PostItem.tsx
@@ -23,9 +23,7 @@ function PostItem({ title, content, createdAt, userName, userIntro }: PostItemPr
   return (
     <Wrapper>
       <Link to="#">
-        <Title>
-          { title }
-        </Title>
+        <Title>{ title }</Title>
       </Link>
       <UserProfileWrapper>
         <UserImage>

--- a/FRONT/src/pages/Home/components/PostItem/PostItem.tsx
+++ b/FRONT/src/pages/Home/components/PostItem/PostItem.tsx
@@ -1,0 +1,106 @@
+import { Link } from 'react-router-dom';
+import { styled } from 'styled-components';
+
+interface PostItemProps {
+  title: string,
+  content: string,
+  createdAt: string,
+  userName: string,
+  userIntro: string
+}
+
+const Wrapper = styled.article`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 30px 5px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
+
+  & > a {
+    text-decoration: none;
+  }
+`;
+
+const Title = styled.h3`
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`
+
+const UserProfileWrapper = styled.div`
+  display: flex;
+  gap: 5px;
+  width: 100%;
+  align-items: center;
+`
+
+const UserImage = styled.figure`
+  padding: 0;
+  margin: 0;
+  width: 35px;
+  height: 35px;
+  border-radius: 100%;
+  overflow: hidden;
+  display: flex:
+  justify-content: center;
+  aligh-items: center;
+  flex: none;
+`;
+
+const UserInfoWrapper = styled.article`
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+`;
+
+const UserNameWrapper = styled.div`
+  display: flex;
+  gap: 2px;
+`;
+
+const UserName = styled.span`
+  font-size: 12px;
+`;
+
+const SubInfo = styled.span`
+  font-size: 12px;
+  color: #AAA;
+`;
+
+const Content = styled.p`
+  display: -webkit-box;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+`
+
+function PostItem({ title, content, createdAt, userName, userIntro }: PostItemProps) {
+  return (
+    <Wrapper>
+      <Link to="#">
+        <Title>
+          { title }
+        </Title>
+      </Link>
+      <UserProfileWrapper>
+        <UserImage>
+          <img src="https://avatars.githubusercontent.com/u/95044821?v=4" alt="profile" width="100%" />
+        </UserImage>
+        <UserInfoWrapper>
+          <UserNameWrapper>
+            <UserName>{ userName }</UserName>
+            <SubInfo>{ createdAt }</SubInfo>
+          </UserNameWrapper>
+          <SubInfo>{ userIntro }</SubInfo>
+        </UserInfoWrapper>
+      </UserProfileWrapper>
+      <Link to="#">
+        <Content>{ content }</Content>
+      </Link>
+    </Wrapper>
+  )
+}
+
+export default PostItem;

--- a/FRONT/src/pages/Home/components/PostItem/PostItem.tsx
+++ b/FRONT/src/pages/Home/components/PostItem/PostItem.tsx
@@ -1,5 +1,15 @@
 import { Link } from 'react-router-dom';
-import { styled } from 'styled-components';
+import { 
+  Content, 
+  SubInfo, 
+  Title, 
+  UserImage, 
+  UserInfoWrapper, 
+  UserName, 
+  UserNameWrapper, 
+  UserProfileWrapper, 
+  Wrapper } 
+  from './PostItem.style';
 
 interface PostItemProps {
   title: string,
@@ -8,73 +18,6 @@ interface PostItemProps {
   userName: string,
   userIntro: string
 }
-
-const Wrapper = styled.article`
-  width: 100%;
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-  padding: 30px 5px;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.15);
-
-  & > a {
-    text-decoration: none;
-  }
-`;
-
-const Title = styled.h3`
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-`
-
-const UserProfileWrapper = styled.div`
-  display: flex;
-  gap: 5px;
-  width: 100%;
-  align-items: center;
-`
-
-const UserImage = styled.figure`
-  padding: 0;
-  margin: 0;
-  width: 35px;
-  height: 35px;
-  border-radius: 100%;
-  overflow: hidden;
-  display: flex:
-  justify-content: center;
-  aligh-items: center;
-  flex: none;
-`;
-
-const UserInfoWrapper = styled.article`
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-`;
-
-const UserNameWrapper = styled.div`
-  display: flex;
-  gap: 2px;
-`;
-
-const UserName = styled.span`
-  font-size: 12px;
-`;
-
-const SubInfo = styled.span`
-  font-size: 12px;
-  color: #AAA;
-`;
-
-const Content = styled.p`
-  display: -webkit-box;
-  -webkit-line-clamp: 5;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-`
 
 function PostItem({ title, content, createdAt, userName, userIntro }: PostItemProps) {
   return (


### PR DESCRIPTION
<!-- PR 제목을 작성할 때 "제목 (#이슈번호)" 형태로 작성해주세요. -->

### 🔍 개요
<!-- 이 PR의 목적과 간략한 내용을 설명해주세요. -->
PostItem 컴포넌트 레이아웃을 구현했습니다.

### ✨ 작업 내용
<!-- 코드 변경의 주요 내용을 요약해주세요. -->
- PostItem을 일단 Home page 안에서만 사용한다고 생각하고 Home 안에 컴포넌트로 구성했습니다.
- 이미지는 아직 유저 정보를 얼마나 response 해주는지 몰라서 그냥 static하게 넣어뒀습니다. 나중에 필요하면 수정하겠습니다.
- `App.tsx`파일에 Routes 설정했습니다. 나중에 `path="*"`로 404페이지 구성해야할 것 같습니다.
- props도 나중에 보고 수정하겠습니다.

### ✅ 체크리스트
<!-- 각 항목을 확인하고 체크해주세요. -->
- [x] 코드가 제대로 빌드되는지 확인했습니다.
- [x] 문서(예: README, API 문서)가 업데이트되었거나 업데이트가 필요하지 않습니다.
- [x] PR에 연결된 이슈가 있는 경우, 해당 이슈 번호를 링크했습니다.

### 🔗 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 작성해주세요. 예: #123, #456 -->
Related to #5 

### 💬 리뷰 요구사항 (option)
<!-- 
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
예: ~~ 부분 코드가 시인성이 나쁜 것 같습니다. 해결책좀요 ㅠㅠ... 
-->
`PostItem.tsx`에 내부 요소들을 분리 안하고 다 넣었는데 코드 가독성이 좀 별로인 것 같긴 하네요. 내부 요소들을 따로 독립적인 컴포넌트로 만드는게 좋을지, 아니면 그대로 두는게 더 나을지 한번 봐주시면 감사하겠습니다.