### PR TITLE
태그 컴포넌트 구현 (#5)

### DIFF
--- a/BACK/spring-app/.gitignore
+++ b/BACK/spring-app/.gitignore
@@ -35,3 +35,6 @@ out/
 
 ### VS Code ###
 .vscode/
+
+# 환경 설정 파일
+application.properties

--- a/BACK/spring-app/src/main/java/com/starchive/springapp/category/controller/CategoryController.java
+++ b/BACK/spring-app/src/main/java/com/starchive/springapp/category/controller/CategoryController.java
@@ -1,0 +1,18 @@
+package com.starchive.springapp.category.controller;
+
+import com.starchive.springapp.category.dto.CategoryListTreeResponse;
+import com.starchive.springapp.category.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class CategoryController {
+    private final CategoryService categoryService;
+
+    @GetMapping("/categorys")
+    public CategoryListTreeResponse showCategories() {
+        return categoryService.findAll();
+    }
+}

--- a/BACK/spring-app/src/main/java/com/starchive/springapp/category/controller/CategoryController.java
+++ b/BACK/spring-app/src/main/java/com/starchive/springapp/category/controller/CategoryController.java
@@ -2,16 +2,20 @@ package com.starchive.springapp.category.controller;
 
 import com.starchive.springapp.category.dto.CategoryListTreeResponse;
 import com.starchive.springapp.category.service.CategoryService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@Tag(name = "카테고리")
 public class CategoryController {
     private final CategoryService categoryService;
 
     @GetMapping("/categorys")
+    @Operation(summary = "카테고리 목록 전체 조회")
     public CategoryListTreeResponse showCategories() {
         return categoryService.findAll();
     }

--- a/BACK/spring-app/src/main/java/com/starchive/springapp/category/domain/Category.java
+++ b/BACK/spring-app/src/main/java/com/starchive/springapp/category/domain/Category.java
@@ -1,0 +1,48 @@
+package com.starchive.springapp.category.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class Category {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parentId")
+    private Category parent;
+
+    @Column(length = 100)
+    String name;
+
+    @OneToMany(mappedBy = "parent", fetch = FetchType.LAZY)
+    private List<Category> children = new ArrayList<>();
+
+    public Category(String name, Category parent) {
+        this.name = name;
+        this.parent = parent;
+        if (parent != null) {
+            changeParent(parent);
+        }
+    }
+
+    private void changeParent(Category parent) {
+        this.parent = parent;
+        parent.getChildren().add(this);
+    }
+
+}

--- a/BACK/spring-app/src/main/java/com/starchive/springapp/category/domain/Category.java
+++ b/BACK/spring-app/src/main/java/com/starchive/springapp/category/domain/Category.java
@@ -22,6 +22,7 @@ import lombok.NoArgsConstructor;
 public class Category {
     @Id
     @GeneratedValue
+    @Column(name = "categoryId")
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/BACK/spring-app/src/main/java/com/starchive/springapp/category/domain/Category.java
+++ b/BACK/spring-app/src/main/java/com/starchive/springapp/category/domain/Category.java
@@ -8,6 +8,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AccessLevel;
@@ -17,6 +18,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
+@Table(name = "Categorys")
 public class Category {
     @Id
     @GeneratedValue

--- a/BACK/spring-app/src/main/java/com/starchive/springapp/category/dto/CategoryDto.java
+++ b/BACK/spring-app/src/main/java/com/starchive/springapp/category/dto/CategoryDto.java
@@ -1,6 +1,7 @@
 package com.starchive.springapp.category.dto;
 
 import com.starchive.springapp.category.domain.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.Getter;
@@ -9,8 +10,15 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class CategoryDto {
+    @Schema(description = "카테고리 식별 id 값", example = "1")
     private Long id;
+    @Schema(description = "카테고리 이름", example = "알고리즘")
     private String name;
+    @Schema(description = "하위 카테고리 목록", example = "{"
+            + "          \"id\": 2,\n"
+            + "          \"name\": \"자료구조\",\n"
+            + "          \"children\": null\n"
+            + "        }")
     private List<CategoryDto> children;
 
     public static CategoryDto from(Category category) {

--- a/BACK/spring-app/src/main/java/com/starchive/springapp/category/dto/CategoryDto.java
+++ b/BACK/spring-app/src/main/java/com/starchive/springapp/category/dto/CategoryDto.java
@@ -1,0 +1,34 @@
+package com.starchive.springapp.category.dto;
+
+import com.starchive.springapp.category.domain.Category;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CategoryDto {
+    private Long id;
+    private String name;
+    private List<CategoryDto> children;
+
+    public static CategoryDto from(Category category) {
+        CategoryDto categoryDto = new CategoryDto();
+        categoryDto.id = category.getId();
+        categoryDto.name = category.getName();
+        categoryDto.children = new ArrayList<>();
+        category.getChildren()
+                .forEach(child -> categoryDto.children.add(CategoryDto.of(child.getId(), child.getName())));
+
+        return categoryDto;
+    }
+
+    public static CategoryDto of(Long id, String name) {
+        CategoryDto categoryDto = new CategoryDto();
+        categoryDto.id = id;
+        categoryDto.name = name;
+
+        return categoryDto;
+    }
+}

--- a/BACK/spring-app/src/main/java/com/starchive/springapp/category/dto/CategoryListTreeResponse.java
+++ b/BACK/spring-app/src/main/java/com/starchive/springapp/category/dto/CategoryListTreeResponse.java
@@ -1,0 +1,20 @@
+package com.starchive.springapp.category.dto;
+
+import com.starchive.springapp.category.domain.Category;
+import java.util.List;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CategoryListTreeResponse {
+    List<CategoryDto> roots;
+
+    public static CategoryListTreeResponse from(List<Category> roots) {
+        CategoryListTreeResponse categoryListTreeResponse = new CategoryListTreeResponse();
+        categoryListTreeResponse.roots = roots.stream().map(CategoryDto::from).toList();
+        return categoryListTreeResponse;
+    }
+
+}
+

--- a/BACK/spring-app/src/main/java/com/starchive/springapp/category/dto/CategoryListTreeResponse.java
+++ b/BACK/spring-app/src/main/java/com/starchive/springapp/category/dto/CategoryListTreeResponse.java
@@ -1,6 +1,7 @@
 package com.starchive.springapp.category.dto;
 
 import com.starchive.springapp.category.domain.Category;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.util.List;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -8,6 +9,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class CategoryListTreeResponse {
+    @Schema(description = "최상위 카테고리 목록")
     List<CategoryDto> roots;
 
     public static CategoryListTreeResponse from(List<Category> roots) {

--- a/BACK/spring-app/src/main/java/com/starchive/springapp/category/repository/CategoryRepository.java
+++ b/BACK/spring-app/src/main/java/com/starchive/springapp/category/repository/CategoryRepository.java
@@ -1,6 +1,7 @@
 package com.starchive.springapp.category.repository;
 
 import com.starchive.springapp.category.domain.Category;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -10,4 +11,6 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
     @Query("SELECT c FROM Category c LEFT JOIN FETCH c.children WHERE c.id = :id")
     Optional<Category> findByIdWithChildren(@Param("id") Long id);
 
+    @Query("SELECT DISTINCT c FROM Category c LEFT JOIN FETCH c.children WHERE c.parent IS NULL")
+    List<Category> findRootCategoriesWithChildren();
 }

--- a/BACK/spring-app/src/main/java/com/starchive/springapp/category/repository/CategoryRepository.java
+++ b/BACK/spring-app/src/main/java/com/starchive/springapp/category/repository/CategoryRepository.java
@@ -1,0 +1,13 @@
+package com.starchive.springapp.category.repository;
+
+import com.starchive.springapp.category.domain.Category;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+    @Query("SELECT c FROM Category c LEFT JOIN FETCH c.children WHERE c.id = :id")
+    Optional<Category> findByIdWithChildren(@Param("id") Long id);
+
+}

--- a/BACK/spring-app/src/main/java/com/starchive/springapp/category/service/CategoryService.java
+++ b/BACK/spring-app/src/main/java/com/starchive/springapp/category/service/CategoryService.java
@@ -1,0 +1,20 @@
+package com.starchive.springapp.category.service;
+
+import com.starchive.springapp.category.domain.Category;
+import com.starchive.springapp.category.dto.CategoryListTreeResponse;
+import com.starchive.springapp.category.repository.CategoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+    private final CategoryRepository categoryRepository;
+
+    public CategoryListTreeResponse findAll() {
+        List<Category> rootCateGories = categoryRepository.findRootCategoriesWithChildren();
+        return CategoryListTreeResponse.from(rootCateGories);
+    }
+
+}

--- a/BACK/spring-app/src/test/java/com/starchive/springapp/category/controller/CategoryControllerTest.java
+++ b/BACK/spring-app/src/test/java/com/starchive/springapp/category/controller/CategoryControllerTest.java
@@ -1,0 +1,58 @@
+package com.starchive.springapp.category.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.starchive.springapp.category.domain.Category;
+import com.starchive.springapp.category.repository.CategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+@AutoConfigureMockMvc
+class CategoryControllerTest {
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void init() {
+        //given
+        Category parent = new Category("알고리즘", null);
+        Category child1 = new Category("자료구조", parent);
+        Category child2 = new Category("다이나믹프로그래밍", parent);
+        Category parent1 = new Category("프로젝트", null);
+        Category child3 = new Category("요구사항", parent1);
+        categoryRepository.save(parent);
+        categoryRepository.save(child1);
+        categoryRepository.save(child2);
+        categoryRepository.save(parent1);
+        categoryRepository.save(child3);
+    }
+
+    @Test
+    public void 목록_전체_조회_테스트() throws Exception {
+        // when
+        mockMvc.perform(get("/categorys")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.roots").isArray())
+                .andExpect(jsonPath("$.roots[0].name").value("알고리즘"))
+                .andExpect(jsonPath("$.roots[0].children").isArray())
+                .andExpect(jsonPath("$.roots[0].children[0].name").value("자료구조"))
+                .andExpect(jsonPath("$.roots[0].children[1].name").value("다이나믹프로그래밍"))
+                .andExpect(jsonPath("$.roots[1].name").value("프로젝트"))
+                .andExpect(jsonPath("$.roots[1].children[0].name").value("요구사항"));
+
+    }
+}

--- a/BACK/spring-app/src/test/java/com/starchive/springapp/category/dto/CategoryDtoTest.java
+++ b/BACK/spring-app/src/test/java/com/starchive/springapp/category/dto/CategoryDtoTest.java
@@ -1,0 +1,47 @@
+package com.starchive.springapp.category.dto;
+
+import com.starchive.springapp.category.domain.Category;
+import com.starchive.springapp.category.repository.CategoryRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class CategoryDtoTest {
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void DTO_단일_변환_테스트() {
+        //given
+        Category parent = new Category("알고리즘", null);
+        Category child1 = new Category("자료구조", parent);
+        Category child2 = new Category("다이나믹프로그래밍", parent);
+        System.out.println("---------------------쿼리1");
+        categoryRepository.save(parent);
+        categoryRepository.save(child1);
+        categoryRepository.save(child2);
+        System.out.println("---------------------쿼리2");
+        // 트랜잭션 종료 (영속성 컨텍스트 초기화)
+        entityManager.flush();
+        entityManager.clear();
+        System.out.println("---------------------쿼리3");
+        Category findOne = categoryRepository.findByIdWithChildren(parent.getId()).get();
+        System.out.println("---------------------쿼리4");
+
+        //when
+        CategoryDto categoryDto = CategoryDto.from(findOne);
+
+        //then
+        Assertions.assertThat(categoryDto.getChildren().size()).isEqualTo(2);
+    }
+
+}

--- a/BACK/spring-app/src/test/java/com/starchive/springapp/category/dto/CategoryListTreeResponseTest.java
+++ b/BACK/spring-app/src/test/java/com/starchive/springapp/category/dto/CategoryListTreeResponseTest.java
@@ -1,0 +1,61 @@
+package com.starchive.springapp.category.dto;
+
+import com.starchive.springapp.category.domain.Category;
+import com.starchive.springapp.category.repository.CategoryRepository;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+import java.util.List;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class CategoryListTreeResponseTest {
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Test
+    void DTO_트리_변환_테스트() {
+        //given
+        Category parent1 = new Category("알고리즘", null);
+        Category child1 = new Category("자료구조", parent1);
+        Category child2 = new Category("다이나믹프로그래밍", parent1);
+        Category child4 = new Category("그리디", parent1);
+        Category parent2 = new Category("프로젝트", null);
+        Category child3 = new Category("요구사항", parent2);
+        Category parent3 = new Category("회고", null);
+        categoryRepository.save(parent1);
+        categoryRepository.save(child1);
+        categoryRepository.save(child2);
+        categoryRepository.save(child4);
+        categoryRepository.save(parent2);
+        categoryRepository.save(child3);
+        categoryRepository.save(parent3);
+        System.out.println("---------------------쿼리1");
+        // 트랜잭션 종료 (영속성 컨텍스트 초기화)
+        entityManager.flush();
+        entityManager.clear();
+        System.out.println("---------------------쿼리2");
+
+        //when
+        List<Category> rootCategoriesWithChildren = categoryRepository.findRootCategoriesWithChildren();
+        System.out.println("---------------------쿼리3");
+
+        for (Category rootCategories : rootCategoriesWithChildren) {
+            System.out.println("root " + rootCategories.getName());
+            for (Category child : rootCategories.getChildren()) {
+                System.out.print(child.getName() + " ");
+            }
+            System.out.println();
+        }
+        //then
+        Assertions.assertThat(rootCategoriesWithChildren.size()).isEqualTo(3);
+    }
+
+}

--- a/BACK/spring-app/src/test/java/com/starchive/springapp/category/repository/CategoryRepositoryTest.java
+++ b/BACK/spring-app/src/test/java/com/starchive/springapp/category/repository/CategoryRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.starchive.springapp.category.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.starchive.springapp.category.domain.Category;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class CategoryRepositoryTest {
+    @Autowired
+    CategoryRepository categoryRepository;
+
+    @Test
+    public void 카테고리_단일_저장_테스트() throws Exception {
+        //given
+        Category category = new Category("스터디", null);
+        Category save = categoryRepository.save(category);
+        //when
+        Category findOne = categoryRepository.findById(category.getId()).get();
+        //then
+        assertThat(findOne).isEqualTo(category);
+    }
+
+    @Test
+    void 카테고리_여러개_저장_부모_자식_관계_테스트() {
+        //given
+        Category category1 = new Category("스터디", null);
+        Category category2 = new Category("디자인패턴", category1);
+        categoryRepository.save(category1);
+        categoryRepository.save(category2);
+
+        Category findParent = categoryRepository.findById(category1.getId()).get();
+        Category findChild = categoryRepository.findById(category2.getId()).get();
+
+        //then
+        assertThat(findParent.getChildren().size()).isEqualTo(1);
+        assertThat(findChild.getParent().getId()).isEqualTo(category1.getId());
+    }
+
+    @Test
+    public void 카테고리_여러개_저장_테스트() throws Exception {
+        //given
+        Category parent = new Category("스터디", null);
+        Category child1 = new Category("디자인패턴", parent);
+        Category descendent = new Category("싱글톤", child1);
+        Category child2 = new Category("소프트웨어공학", parent);
+        categoryRepository.save(parent);
+        categoryRepository.save(child1);
+        categoryRepository.save(descendent);
+        categoryRepository.save(child2);
+
+        //when
+        Category findParent = categoryRepository.findById(parent.getId()).get();
+        Category findChild = findParent.getChildren().stream().filter(category -> category.getName().equals("디자인패턴"))
+                .findFirst().get();
+        Category findDescendant = findChild.getChildren().stream().findFirst().get();
+        //then
+        assertThat(findParent.getChildren().size()).isEqualTo(2);
+        assertThat(findDescendant.getName()).isEqualTo("싱글톤");
+    }
+}

--- a/BACK/spring-app/src/test/java/com/starchive/springapp/category/service/CategoryServiceTest.java
+++ b/BACK/spring-app/src/test/java/com/starchive/springapp/category/service/CategoryServiceTest.java
@@ -1,0 +1,55 @@
+package com.starchive.springapp.category.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.starchive.springapp.category.domain.Category;
+import com.starchive.springapp.category.dto.CategoryListTreeResponse;
+import com.starchive.springapp.category.repository.CategoryRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@Transactional
+class CategoryServiceTest {
+    @Autowired
+    CategoryRepository categoryRepository;
+    @Autowired
+    CategoryService categoryService;
+
+    @BeforeEach
+    void init() {
+        //given
+        Category parent1 = new Category("알고리즘", null);
+        Category child1 = new Category("자료구조", parent1);
+        Category child2 = new Category("다이나믹프로그래밍", parent1);
+        Category parent2 = new Category("프로젝트", null);
+        Category child3 = new Category("요구사항", parent2);
+        Category parent3 = new Category("회고", null);
+        categoryRepository.save(parent1);
+        categoryRepository.save(child1);
+        categoryRepository.save(child2);
+        categoryRepository.save(parent2);
+        categoryRepository.save(child3);
+        categoryRepository.save(parent3);
+    }
+
+
+    @Test
+    void 전체_목록_조회_테스트() {
+        // when
+        CategoryListTreeResponse response = categoryService.findAll();
+
+        // then
+        assertThat(response.getRoots()).hasSize(3);
+        assertThat(response.getRoots().get(0).getName()).isEqualTo("알고리즘");
+        assertThat(response.getRoots().get(0).getChildren()).hasSize(2);
+        assertThat(response.getRoots().get(0).getChildren().get(0).getName()).isEqualTo("자료구조");
+        assertThat(response.getRoots().get(0).getChildren().get(1).getName()).isEqualTo("다이나믹프로그래밍");
+        assertThat(response.getRoots().get(1).getName()).isEqualTo("프로젝트");
+        assertThat(response.getRoots().get(1).getChildren().get(0).getName()).isEqualTo("요구사항");
+    }
+
+}

--- a/FRONT/src/components/TagWrapper/TagWrapper.style.tsx
+++ b/FRONT/src/components/TagWrapper/TagWrapper.style.tsx
@@ -1,9 +1,8 @@
 import styled from "styled-components";
 
-export const Tag = styled.div`
+export const Tag = styled.span`
   display: inline-block;
   padding: 2px 5px;
-  font-size: 12px;
   background-color: var(--sub-color);
   color: var(--text-color);  // Fix the typo here
   width: fit-content;

--- a/FRONT/src/components/TagWrapper/TagWrapper.style.tsx
+++ b/FRONT/src/components/TagWrapper/TagWrapper.style.tsx
@@ -1,0 +1,16 @@
+import styled from "styled-components";
+
+export const Tag = styled.div`
+  display: inline-block;
+  padding: 2px 5px;
+  font-size: 12px;
+  background-color: var(--sub-color);
+  color: var(--text-color);  // Fix the typo here
+  width: fit-content;
+  margin-right: 5px;
+  margin-bottom: 5px;
+`;
+
+export const TagList = styled.div`
+    display: inline-block;
+`;

--- a/FRONT/src/components/TagWrapper/TagWrapper.tsx
+++ b/FRONT/src/components/TagWrapper/TagWrapper.tsx
@@ -1,0 +1,17 @@
+import { TagList, Tag } from "../TagWrapper/TagWrapper.style";
+
+interface TagProps {
+  tagList: string[];
+}
+
+function TagWrapper({ tagList }: TagProps) {
+  return (
+    <TagList>
+      {tagList.map((tag, index) => (
+        <Tag key={index}>{tag}</Tag>
+      ))}
+    </TagList>
+  );
+}
+
+export default TagWrapper;

--- a/FRONT/src/pages/Home/Home.tsx
+++ b/FRONT/src/pages/Home/Home.tsx
@@ -2,6 +2,7 @@ import styled from "styled-components";
 import PostItem from "./components/PostItem/PostItem";
 import PagingButton from "@_components/PagingButton/PagingButton";
 import { useState } from "react";
+import TagWrapper from "../../components/TagWrapper/TagWrapper";
 
 const Wrapper = styled.main`
   max-width: 700px;
@@ -21,37 +22,74 @@ const PagingButtonWrapper = styled.section`
   padding: 20px 0;
 `;
 
+const ContentWrapper = styled.section`
+  display: flex;
+  flex-direction: row;
+  gap: 20px;
+
+  @media screen and (max-width: 768px) {
+    flex-direction: column;
+    gap: 30px;
+  }
+`;
+
+const TagContainer = styled.section`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 300px;
+
+  @media screen and (max-width: 768px) {
+    width: 100%;
+  }
+`;
+
+const TagTitle = styled.h3`
+  color: var(--text-color);
+`;
+
+
 function Home() {
   const [currentPage, setCurrentPage] = useState<number>(1);
-
+  const tagList = ["Design Pattern", "Factory Pattern", "CI/CD", "DevOps", "Software Engineering","Design Pattern", "Factory Pattern", "CI/CD", "DevOps", "Software Engineering"];
+  
   return (
     <Wrapper>
-      <PostItemContainer>
-        <PostItem 
-          title="뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목"
-          createdAt="2024-11-12"
-          content="요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.
-          요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. "
-          userIntro="어쩌구 저쩌구 개발자입니다."
-          userName="도안탄히엔"
-          />
-        <PostItem 
-          title="뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목"
-          createdAt="2024-11-12"
-          content="요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.
-          요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. "
-          userIntro="어쩌구 저쩌구 개발자입니다."
-          userName="도안탄히엔"
-          />
-        <PostItem 
-          title="뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목"
-          createdAt="2024-11-12"
-          content="요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.
-          요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. "
-          userIntro="어쩌구 저쩌구 개발자입니다."
-          userName="도안탄히엔"
-          />
-      </PostItemContainer>
+      <ContentWrapper>
+        <PostItemContainer>
+          <PostItem 
+            title="뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목"
+            createdAt="2024-11-12"
+            content="요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.
+            요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. "
+            userIntro="어쩌구 저쩌구 개발자입니다."
+            userName="도안탄히엔"
+            tagList={["Design Pattern", "Factory Pattern"]}
+            />
+          <PostItem 
+            title="뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목"
+            createdAt="2024-11-12"
+            content="요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.
+            요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. "
+            userIntro="어쩌구 저쩌구 개발자입니다."
+            userName="도안탄히엔"
+            tagList={["Design Pattern", "Factory Pattern"]}
+            />
+          <PostItem 
+            title="뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목"
+            createdAt="2024-11-12"
+            content="요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.
+            요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. "
+            userIntro="어쩌구 저쩌구 개발자입니다."
+            userName="도안탄히엔"
+            tagList={["Design Pattern", "Factory Pattern"]}
+            />
+        </PostItemContainer>
+        <TagContainer>
+          <TagTitle>#태그</TagTitle>
+          <TagWrapper tagList={tagList} />
+        </TagContainer>
+      </ContentWrapper>
       <PagingButtonWrapper>
         <PagingButton totalPages={10} currentPage={currentPage} setCurrentPage={setCurrentPage} />
       </PagingButtonWrapper>

--- a/FRONT/src/pages/Home/Home.tsx
+++ b/FRONT/src/pages/Home/Home.tsx
@@ -64,7 +64,6 @@ function Home() {
             요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. "
             userIntro="어쩌구 저쩌구 개발자입니다."
             userName="도안탄히엔"
-            tagList={["Design Pattern", "Factory Pattern"]}
             />
           <PostItem 
             title="뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목"
@@ -73,7 +72,6 @@ function Home() {
             요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. "
             userIntro="어쩌구 저쩌구 개발자입니다."
             userName="도안탄히엔"
-            tagList={["Design Pattern", "Factory Pattern"]}
             />
           <PostItem 
             title="뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목뭐시기 제목"
@@ -82,7 +80,6 @@ function Home() {
             요거슨 내용 입니다. 요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다.요거슨 내용 입니다. "
             userIntro="어쩌구 저쩌구 개발자입니다."
             userName="도안탄히엔"
-            tagList={["Design Pattern", "Factory Pattern"]}
             />
         </PostItemContainer>
         <TagContainer>

--- a/FRONT/src/pages/Home/components/PostItem/PostItem.tsx
+++ b/FRONT/src/pages/Home/components/PostItem/PostItem.tsx
@@ -11,16 +11,18 @@ import {
   UserProfileWrapper, 
   Wrapper } 
   from './PostItem.style';
+import TagWrapper from '@_components/TagWrapper/TagWrapper';
 
 interface PostItemProps {
   title: string,
   content: string,
   createdAt: string,
   userName: string,
-  userIntro: string
+  userIntro: string,
+  tagList: string[]
 }
 
-function PostItem({ title, content, createdAt, userName, userIntro }: PostItemProps) {
+function PostItem({ title, content, createdAt, userName, userIntro, tagList }: PostItemProps) {
   return (
     <Wrapper>
       <TagContainer>
@@ -44,6 +46,7 @@ function PostItem({ title, content, createdAt, userName, userIntro }: PostItemPr
       <Link to="#">
         <Content>{ content }</Content>
       </Link>
+      <TagWrapper tagList={tagList} />
     </Wrapper>
   )
 }


### PR DESCRIPTION
<!-- PR 제목을 작성할 때 "제목 (#이슈번호)" 형태로 작성해주세요. -->

### 🔍 개요
<!-- 이 PR의 목적과 간략한 내용을 설명해주세요. -->
태그 구현
### ✨ 작업 내용
<!-- 코드 변경의 주요 내용을 요약해주세요. -->
- TagWrapper 공동 컴포넌트 구현
- PostItem 밑에 태그 추가
- Home에 TagContainer 영역을 생성하고 TagWrapper 추가
- 모바일 화면에서 태그 위치 변경

### ✅ 체크리스트
<!-- 각 항목을 확인하고 체크해주세요. -->
- [x] 코드가 제대로 빌드되는지 확인했습니다.
- [x] 문서(예: README, API 문서)가 업데이트되었거나 업데이트가 필요하지 않습니다.
- [x] PR에 연결된 이슈가 있는 경우, 해당 이슈 번호를 링크했습니다.

### 🔗 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 작성해주세요. 예: #123, #456 -->
Related #5 
### 💬 리뷰 요구사항 (option)
<!-- 
리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
예: ~~ 부분 코드가 시인성이 나쁜 것 같습니다. 해결책좀요 ㅠㅠ... 
--> 
- 종혁님의 만든 PostItem 컴포넌트에 태그를 추가했어요
- Home에서 TagContainer의 width를 300px로 설정했어요. 사이드-메인 콘텐츠-태그 영역 크기의 비율을 정하면 수정하겠습니다

### 📎 추가 정보 (option)
<!-- PR 검토에 참고할 추가 정보나 의견이 있다면 작성해주세요. -->
<img width="554" alt="image" src="https://github.com/user-attachments/assets/76970a35-6842-4e7a-bd4e-bdb637d21d56">
  
<img width="770" alt="image" src="https://github.com/user-attachments/assets/54f72294-c5b2-4d5c-b01a-1316a9506dba">


