### PR TITLE
태그별 글 조회 api 연동(#5)

### DIFF
--- a/FRONT/src/components/TagWrapper/TagWrapper.style.ts
+++ b/FRONT/src/components/TagWrapper/TagWrapper.style.ts
@@ -1,13 +1,14 @@
 import styled from "styled-components";
 
-export const Tag = styled.span`
+export const Tag = styled.span<{ $isSelected: boolean }>`
   display: inline-block;
   padding: 2px 5px;
-  background-color: var(--sub-color);
+  background-color: ${props => props.$isSelected ? '#EAC58F' : 'var(--sub-color)'};
   color: var(--text-color);
   width: fit-content;
   margin-right: 5px;
   margin-bottom: 5px;
+  cursor: pointer;
 `;
 
 export const TagList = styled.div`

--- a/FRONT/src/components/TagWrapper/TagWrapper.tsx
+++ b/FRONT/src/components/TagWrapper/TagWrapper.tsx
@@ -1,15 +1,27 @@
+import { TagList, Tag } from "./TagWrapper.style";
 
-import { TagList, Tag } from "../TagWrapper/TagWrapper.style";
-
-interface TagProps {
-  tagList: string[];
+interface Tag {
+  id: number;
+  name: string;
 }
 
-function TagWrapper({ tagList }: TagProps) {
+interface TagWrapperProps {
+  tagList: Tag[];
+  onTagClick?: (name: string) => void;
+  selectedTag?: string | null;
+}
+
+function TagWrapper({ tagList, onTagClick, selectedTag }: TagWrapperProps) {
   return (
     <TagList>
       {tagList.map((tag, index) => (
-        <Tag key={index}>{tag}</Tag>
+        <Tag
+          key={index}
+          onClick={() => onTagClick && onTagClick(tag.name)}
+          $isSelected={tag.name === selectedTag}
+        >
+          {tag.name}
+        </Tag>
       ))}
     </TagList>
   );

--- a/FRONT/src/components/TagWrapper/useTag.ts
+++ b/FRONT/src/components/TagWrapper/useTag.ts
@@ -1,0 +1,31 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import { fetchPostList } from "../../services/postApi";
+import { fetchPostsByTag } from "../../services/tagApi";
+import { Post } from "../../types/post";
+import { ApiResponse } from "../../services/api";
+
+export const useTag = () => {
+  const [selectedTag, setSelectedTag] = useState<string | null>(null);
+
+  const { data, refetch } = useQuery<ApiResponse<Post[]>>({
+    queryKey: selectedTag ? ["postData", selectedTag] : ["postData"],
+    queryFn: () =>
+      selectedTag ? fetchPostsByTag(selectedTag) : fetchPostList(), //태그가 선택되지 않았을 때는 fetchPostList()만 호출
+  });
+
+  const handleTagClick = (tagName: string) => {
+    const newSelectedTag = selectedTag === tagName ? null : tagName;
+    setSelectedTag(newSelectedTag);
+
+    if (newSelectedTag) {
+      refetch();
+    }
+  };
+
+  return {
+    selectedTag,
+    posts: data?.data || [],
+    handleTagClick,
+  };
+};

--- a/FRONT/src/pages/Home/Home.tsx
+++ b/FRONT/src/pages/Home/Home.tsx
@@ -1,24 +1,33 @@
 import PostItem from "./components/PostItem/PostItem";
 import PagingButton from "@_components/PagingButton/PagingButton";
 import { useState } from "react";
-import { useQuery } from "@tanstack/react-query";
 import { PagingButtonWrapper, PostItemContainer, Wrapper } from "./Home.style";
-import { fetchPostList } from "../../services/postApi";
 import { Post } from "../../types/post";
-import { ApiResponse } from "../../services/api";
-// import TagWrapper from "../../components/TagWrapper/TagWrapper";
+import TagWrapper from "../../components/TagWrapper/TagWrapper";
+import { useTag } from "../../components/TagWrapper/useTag";
 
 function Home() {
   const [currentPage, setCurrentPage] = useState<number>(1);
-  // const tagList = ["Design Pattern", "Factory Pattern", "CI/CD", "DevOps", "Software Engineering","Design Pattern", "Factory Pattern", "CI/CD", "DevOps", "Software Engineering"];
+  const tagList = [
+    { id: 1, name: "Design Pattern" },
+    { id: 2, name: "Factory Pattern" },
+    { id: 3, name: "CI/CD" },
+    { id: 4, name: "DevOps" },
+    { id: 5, name: "Software Engineering" },
+  ];  
 
-  const { data } = useQuery<ApiResponse<Post[]>>({ queryKey: ['postData'], queryFn: () => fetchPostList() });
+  const { 
+    selectedTag,
+    posts, 
+    handleTagClick 
+  } = useTag();
 
   return (
     <Wrapper>
+      <TagWrapper tagList={tagList} onTagClick={handleTagClick} selectedTag={selectedTag}/>
       <PostItemContainer>
         {
-          data?.data.map((postItem: Post, i: number) => 
+          posts.map((postItem: Post, i: number) => 
             <PostItem 
               title={postItem.title}
               createdAt={postItem.createdAt}

--- a/FRONT/src/services/tagApi.ts
+++ b/FRONT/src/services/tagApi.ts
@@ -1,0 +1,4 @@
+import { getRequest } from "./api";
+import { Post } from "../types/post";
+
+export const fetchPostsByTag = (tagName: string) => getRequest<Post[]>('/hashtag', { params: { tag: tagName } });


### PR DESCRIPTION
<!-- PR 제목을 작성할 때 "제목 (#이슈번호)" 형태로 작성해주세요. -->

### 🔍 개요
<!-- 이 PR의 목적과 간략한 내용을 설명해주세요. -->
태그별 글 조회 api 연동
### ✨ 작업 내용
<!-- 코드 변경의 주요 내용을 요약해주세요. -->
- 선택한 태그를 진한 색깔로 변경
- useTag 훅 구현: 태그를 선택하지 않으면 전체 post를 가져오는 fetchPostList() 호출, 하나 태그를 선택하면 fetchPostsByTag(selectedTag) 호출. 다른 태그를 클릭하면 refresh 호출
- 예전에 빠졌던 태그 id를 <Tag'>에 추가

### ✅ 체크리스트
<!-- 각 항목을 확인하고 체크해주세요. -->
- [x] 코드가 제대로 빌드되는지 확인했습니다.
- [x] 문서(예: README, API 문서)가 업데이트되었거나 업데이트가 필요하지 않습니다.
- [x] PR에 연결된 이슈가 있는 경우, 해당 이슈 번호를 링크했습니다.

### 🔗 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 작성해주세요. 예: #123, #456 -->
Related #5 

### 📎 추가 정보 (option)
<!-- PR 검토에 참고할 추가 정보나 의견이 있다면 작성해주세요. -->
<img width="520" alt="image" src="https://github.com/user-attachments/assets/a78ef3c9-4d69-40b1-9423-1faa5d2ed5c2">
