### PR TITLE
글 상세보기 페이지(Post.tsx)에서 마크다운이 렌더링되지 않는 문제 해결 (#85)

### DIFF
--- a/FRONT/src/components/MarkdownRenderer/CodeBlock.tsx
+++ b/FRONT/src/components/MarkdownRenderer/CodeBlock.tsx
@@ -1,0 +1,40 @@
+import { useEffect, useRef } from "react";
+import { InlineCode } from "./MarkdownRenderer.style";
+import Prism from "prismjs";
+import 'prismjs/themes/prism.css';
+import 'prismjs/components/prism-javascript';
+import 'prismjs/components/prism-typescript';
+import 'prismjs/components/prism-java';
+import 'prismjs/components/prism-python';
+import 'prismjs/components/prism-c';
+import 'prismjs/components/prism-cpp';
+import 'prismjs/components/prism-css';
+import 'prismjs/components/prism-sql';
+import 'prismjs/components/prism-bash';
+import 'prismjs/components/prism-yaml';
+import 'prismjs/components/prism-json';
+
+const CodeBlock = ({ inline, className, children }: { inline?: boolean; className?: string; children: React.ReactNode }) => {
+  const codeRef = useRef<HTMLElement>(null);
+
+  useEffect(() => {
+    if (codeRef.current) {
+      Prism.highlightElement(codeRef.current); // 개별 코드 블록 하이라이트
+    }
+  }, [children]);
+
+  if (inline) {
+    return <InlineCode>{ children }</InlineCode>;
+  }
+
+  const language = className?.replace("language-", "") || "plaintext";
+  const codeString = String(children).replace(/\n$/, "");
+
+  return (
+    <pre className={className}>
+      <code ref={codeRef} className={`language-${language}`}>{ codeString }</code>
+    </pre>
+  );
+};
+
+export default CodeBlock;

--- a/FRONT/src/components/MarkdownRenderer/MarkdownRenderer.style.ts
+++ b/FRONT/src/components/MarkdownRenderer/MarkdownRenderer.style.ts
@@ -1,0 +1,42 @@
+import styled from "styled-components";
+
+export const MarkdownContainer = styled.div`
+  blockquote { // 인용문
+    margin: 0;
+    padding: 8px 16px;
+    border-left: 4px solid var(--point-color);
+    background-color: var(--background-color);
+  }
+
+  ul, ol {
+    display: inline-block;
+    margin: 0;
+    padding-left: 20px;
+  }
+
+  ul ul, ol ol {
+    line-height: 1;
+  }
+
+  hr {
+    background-color: var(--line-color);
+    height: 1px;
+    border: 0;
+  }
+`;
+
+export const InlineCode = styled.code`
+  display: inline;
+  background-color: var(--background-color);
+  color: var(--point-color);
+  padding: 2px 5px;
+  border-radius: 5px;
+`;
+
+export const PreviewImg = styled.img`
+  max-width: 600px;
+  height: auto;
+  object-fit: contain;
+  display: block;
+  margin: 0 auto;
+`;

--- a/FRONT/src/components/MarkdownRenderer/MarkdownRenderer.tsx
+++ b/FRONT/src/components/MarkdownRenderer/MarkdownRenderer.tsx
@@ -1,0 +1,21 @@
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { MarkdownContainer, PreviewImg } from "./MarkdownRenderer.style";
+import CodeBlock from "./CodeBlock";
+
+const MarkdownRenderer = ({ markdown }: { markdown: string }) => {
+  return (
+    <MarkdownContainer>
+      <Markdown
+        children={markdown}
+        remarkPlugins={[remarkGfm]}
+        components={{
+          code: CodeBlock,
+          img: ({ src, alt }) => <PreviewImg src={src} alt={alt} />,
+        }}
+      />
+    </MarkdownContainer>
+  );
+};
+
+export default MarkdownRenderer;

--- a/FRONT/src/pages/CreatePost/components/MarkdownEditor/MarkdownEditor.style.ts
+++ b/FRONT/src/pages/CreatePost/components/MarkdownEditor/MarkdownEditor.style.ts
@@ -35,43 +35,4 @@ export const Editor = styled.textarea`
 
 export const Preview = styled.div`
   ${sharedStyles}
-
-  blockquote { // 인용문
-    margin: 0;
-    padding: 8px 16px;
-    border-left: 4px solid var(--point-color);
-    background-color: var(--background-color);
-  }
-
-  ul, ol {
-    display: inline-block;
-    margin: 0;
-    padding-left: 20px;
-  }
-
-  ul ul, ol ol {
-    line-height: 1;
-  }
-
-  hr {
-    background-color: var(--line-color);
-    height: 1px;
-    border: 0;
-  }
-`;
-
-export const InlineCode = styled.code`
-  display: inline;
-  background-color: var(--background-color);
-  color: var(--point-color);
-  padding: 2px 5px;
-  border-radius: 5px;
-`;
-
-export const PreviewImg = styled.img`
-  max-width: 600px;
-  height: auto;
-  object-fit: contain;
-  display: block;
-  margin: 0 auto;
 `;

--- a/FRONT/src/pages/CreatePost/components/MarkdownEditor/MarkdownEditor.tsx
+++ b/FRONT/src/pages/CreatePost/components/MarkdownEditor/MarkdownEditor.tsx
@@ -1,9 +1,7 @@
 import { useState } from "react";
-import { Container, Editor, Preview, PreviewImg } from "./MarkdownEditor.style";
-import Markdown from "react-markdown";
-import remarkGfm from "remark-gfm";
-import CodeBlock from "./CodeBlock";
+import { Container, Editor, Preview } from "./MarkdownEditor.style";
 import ToolBar from "../ToolBar/ToolBar";
+import MarkdownRenderer from "@_components/MarkdownRenderer/MarkdownRenderer";
 
 interface MarkdownEditorProps {
   markdown: string,
@@ -42,18 +40,7 @@ function MarkdownEditor({
           placeholder={markdownGrammar}
         />
       ) : (
-        <Preview>
-          <Markdown
-            children={markdown}
-            remarkPlugins={[remarkGfm]}
-            components={{
-              code: CodeBlock,
-              img: ({ src, alt }) => (
-                <PreviewImg src={src} alt={alt} />
-              ),
-            }}
-          />
-        </Preview>
+        <Preview><MarkdownRenderer markdown={markdown} /></Preview>
       )}
       <input
         type="file"

--- a/FRONT/src/pages/Post/Post.style.ts
+++ b/FRONT/src/pages/Post/Post.style.ts
@@ -30,6 +30,10 @@ export const Line = styled.div`
   margin: 15px 0;
 `;
 
+export const Content = styled.div`
+  padding: 40px 40px 80px 40px;
+`
+
 export const PostHashTagContainer = styled(HashTagContainer)`
   margin-top: 20px;
 `;

--- a/FRONT/src/pages/Post/Post.style.ts
+++ b/FRONT/src/pages/Post/Post.style.ts
@@ -32,8 +32,8 @@ export const Line = styled.div`
 
 export const Content = styled.div`
   padding: 40px 40px 80px 40px;
+  min-height: calc(100dvh - 640px);
 `
-
 export const PostHashTagContainer = styled(HashTagContainer)`
   margin-top: 20px;
 `;

--- a/FRONT/src/pages/Post/Post.tsx
+++ b/FRONT/src/pages/Post/Post.tsx
@@ -13,6 +13,7 @@ import {
 import { Tag } from "@_components/TagWrapper/TagWrapper.style";
 import { Link } from "react-router-dom";
 import Button from "@_components/Button/Button";
+import MarkdownRenderer from "@_components/MarkdownRenderer/MarkdownRenderer";
 import { useParams } from 'react-router-dom';
 import { useQuery } from '@tanstack/react-query';
 import { fetchPost } from '@_services/postApi';
@@ -70,7 +71,7 @@ function Post() {
           </UserInfoWrapper>
         </UserProfileWrapper>
         <Line/>
-        <Content>{content}</Content>
+        <Content><MarkdownRenderer markdown={content ?? ""} /></Content>
         <PostHashTagContainer>
           {hashTags?.map((tag) => (
             <Tag key={tag.hashTagId} $isSelected={false}>

--- a/FRONT/src/pages/Post/Post.tsx
+++ b/FRONT/src/pages/Post/Post.tsx
@@ -1,4 +1,4 @@
-import { PostContainer, MainContent, ButtonContainer, Line, PostHashTagContainer } from "./Post.style";
+import { PostContainer, MainContent, ButtonContainer, Line, PostHashTagContainer, Content } from "./Post.style";
 import {
   TagContainer,
   Title,
@@ -8,7 +8,6 @@ import {
   UserNameWrapper,
   UserName,
   SubInfo,
-  Content,
 } from "../Home/components/PostItem/PostItem.style";
 import { Tag } from "@_components/TagWrapper/TagWrapper.style";
 import { Link } from "react-router-dom";


### PR DESCRIPTION
<!-- PR 제목을 작성할 때 "제목 (#이슈번호)" 형태로 작성해주세요. -->

### 🔍 개요
<!-- 이 PR의 목적과 간략한 내용을 설명해주세요. -->
글 상세보기 페이지(Post.tsx)에서 마크다운이 렌더링되지 않는 문제 해결

### ✨ 작업 내용
<!-- 코드 변경의 주요 내용을 요약해주세요. -->
- 마크다운 렌더링 관련 파일(CodeBlock.tsx, Markdown 컴포넌트, Markdown 스타일링 코드)을 재사용하기 용이하도록 `src/components/MarkdownRenderer` 폴더로 이동
- `Post.tsx`(글 상세보기 페이지)와 기존의 `CreatePost/MarkdownEditor.tsx`에서 MarkdownRender 컴포넌트를 사용하여 마크다운이 정상적으로 렌더링되도록 수정
- 글 상세 페이지 여백 추가 (40px 40px 80px 40px)
- `Post.tsx`의 글 상세 내용(`Content`)에 min-height를 추가함 (글을 너무 적게 적었을 때 footer가 뜨는 현상을 방지하기 위함

### ✅ 체크리스트
<!-- 각 항목을 확인하고 체크해주세요. -->
- [x]  코드가 제대로 빌드되는지 확인했습니다.
- [x] 문서(예: README, API 문서)가 업데이트되었거나 업데이트가 필요하지 않습니다.
- [x] PR에 연결된 이슈가 있는 경우, 해당 이슈 번호를 링크했습니다.

### 🔗 관련 이슈
<!-- 이 PR과 관련된 이슈 번호를 작성해주세요. 예: #123, #456 -->
Related to #85

### 📎 추가 정보 (option)
<!-- PR 검토에 참고할 추가 정보나 의견이 있다면 작성해주세요. -->
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/2b0a13f8-a98f-4102-91e1-a392e94761af" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/2233f929-5c8e-4ab2-afd7-00567a62c14b" />
<img width="1624" alt="image" src="https://github.com/user-attachments/assets/a83f1d17-b7d8-419b-818c-da67fc382da5" />
